### PR TITLE
[MTDSA-30442]: Remove Tax year specific Ifs config and use Ifs config

### DIFF
--- a/app/shared/config/SharedAppConfig.scala
+++ b/app/shared/config/SharedAppConfig.scala
@@ -41,7 +41,6 @@ class SharedAppConfig @Inject()(val config: ServicesConfig, protected[config] va
 
   def desDownstreamConfig: DownstreamConfig          = downstreamConfig("des")
   def ifsDownstreamConfig: DownstreamConfig          = downstreamConfig("ifs")
-  def tysIfsDownstreamConfig: DownstreamConfig       = downstreamConfig("tys-ifs")
   def hipDownstreamConfig: BasicAuthDownstreamConfig = basicAuthDownstreamConfig("hip")
 
   // API Config

--- a/app/shared/connectors/DownstreamUri.scala
+++ b/app/shared/connectors/DownstreamUri.scala
@@ -34,9 +34,6 @@ object DownstreamUri {
   def IfsUri[Resp](value: String)(implicit appConfig: SharedAppConfig): DownstreamUri[Resp] =
     withStandardStrategy(value, appConfig.ifsDownstreamConfig)
 
-  def TaxYearSpecificIfsUri[Resp](value: String)(implicit appConfig: SharedAppConfig): DownstreamUri[Resp] =
-    withStandardStrategy(value, appConfig.tysIfsDownstreamConfig)
-
   def HipUri[Resp](path: String)(implicit appConfig: SharedAppConfig): DownstreamUri[Resp] =
     DownstreamUri(path, DownstreamStrategy.basicAuthStrategy(appConfig.hipDownstreamConfig))
 

--- a/app/v1/connectors/AmendFinancialDetailsConnector.scala
+++ b/app/v1/connectors/AmendFinancialDetailsConnector.scala
@@ -19,7 +19,7 @@ package v1.connectors
 import config.EmploymentsAppConfig
 import play.api.libs.json.Format.GenericFormat
 import shared.config.SharedAppConfig
-import shared.connectors.DownstreamUri.TaxYearSpecificIfsUri
+import shared.connectors.DownstreamUri.IfsUri
 import shared.connectors.httpparsers.StandardDownstreamHttpParser.readsEmpty
 import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome, DownstreamStrategy, DownstreamUri}
 import uk.gov.hmrc.http.HeaderCarrier
@@ -30,7 +30,8 @@ import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class AmendFinancialDetailsConnector @Inject() (val http: HttpClientV2, val appConfig: SharedAppConfig, employmentsAppConfig: EmploymentsAppConfig) extends BaseDownstreamConnector {
+class AmendFinancialDetailsConnector @Inject() (val http: HttpClientV2, val appConfig: SharedAppConfig, employmentsAppConfig: EmploymentsAppConfig)
+    extends BaseDownstreamConnector {
 
   def amendFinancialDetails(request: AmendFinancialDetailsRequest)(implicit
       hc: HeaderCarrier,
@@ -41,11 +42,12 @@ class AmendFinancialDetailsConnector @Inject() (val http: HttpClientV2, val appC
 
     val downstreamUri =
       if (taxYear.useTaxYearSpecificApi) {
-        TaxYearSpecificIfsUri[Unit](s"income-tax/${taxYear.asTysDownstream}/income/employments/$nino/${employmentId.value}")
+        IfsUri[Unit](s"income-tax/${taxYear.asTysDownstream}/income/employments/$nino/${employmentId.value}")
       } else {
-          DownstreamUri[Unit](s"income-tax/income/employments/$nino/${taxYear.asMtd}/${employmentId.value}",
-            DownstreamStrategy.standardStrategy(employmentsAppConfig.release6DownstreamConfig)
-          )
+        DownstreamUri[Unit](
+          s"income-tax/income/employments/$nino/${taxYear.asMtd}/${employmentId.value}",
+          DownstreamStrategy.standardStrategy(employmentsAppConfig.release6DownstreamConfig)
+        )
       }
 
     put(body, downstreamUri)

--- a/app/v1/connectors/AmendOtherEmploymentConnector.scala
+++ b/app/v1/connectors/AmendOtherEmploymentConnector.scala
@@ -17,7 +17,7 @@
 package v1.connectors
 
 import shared.config.SharedAppConfig
-import shared.connectors.DownstreamUri.{DesUri, TaxYearSpecificIfsUri}
+import shared.connectors.DownstreamUri.{DesUri, IfsUri}
 import shared.connectors.httpparsers.StandardDownstreamHttpParser.readsEmpty
 import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome}
 import uk.gov.hmrc.http.HeaderCarrier
@@ -38,7 +38,7 @@ class AmendOtherEmploymentConnector @Inject() (val http: HttpClientV2, val appCo
     import request._
 
     val downstreamUri = if (taxYear.useTaxYearSpecificApi) {
-      TaxYearSpecificIfsUri[Unit](s"income-tax/income/other/employments/${taxYear.asTysDownstream}/${nino.nino}")
+      IfsUri[Unit](s"income-tax/income/other/employments/${taxYear.asTysDownstream}/${nino.nino}")
     } else {
       DesUri[Unit](s"income-tax/income/other/employments/${nino.nino}/${taxYear.asMtd}")
     }

--- a/app/v1/connectors/CreateAmendNonPayeEmploymentConnector.scala
+++ b/app/v1/connectors/CreateAmendNonPayeEmploymentConnector.scala
@@ -18,7 +18,7 @@ package v1.connectors
 
 import config.EmploymentsAppConfig
 import shared.config.SharedAppConfig
-import shared.connectors.DownstreamUri.TaxYearSpecificIfsUri
+import shared.connectors.DownstreamUri.IfsUri
 import shared.connectors.httpparsers.StandardDownstreamHttpParser.readsEmpty
 import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome, DownstreamStrategy, DownstreamUri}
 import uk.gov.hmrc.http.HeaderCarrier
@@ -29,7 +29,10 @@ import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class CreateAmendNonPayeEmploymentConnector @Inject() (val http: HttpClientV2, val appConfig: SharedAppConfig, employmentsAppConfig: EmploymentsAppConfig) extends BaseDownstreamConnector {
+class CreateAmendNonPayeEmploymentConnector @Inject() (val http: HttpClientV2,
+                                                       val appConfig: SharedAppConfig,
+                                                       employmentsAppConfig: EmploymentsAppConfig)
+    extends BaseDownstreamConnector {
 
   def createAndAmend(request: CreateAmendNonPayeEmploymentRequest)(implicit
       hc: HeaderCarrier,
@@ -39,12 +42,13 @@ class CreateAmendNonPayeEmploymentConnector @Inject() (val http: HttpClientV2, v
     import request._
 
     val uri = if (taxYear.useTaxYearSpecificApi) {
-      TaxYearSpecificIfsUri[Unit](s"income-tax/income/employments/non-paye/${taxYear.asTysDownstream}/${nino.nino}")
+      IfsUri[Unit](s"income-tax/income/employments/non-paye/${taxYear.asTysDownstream}/${nino.nino}")
     } else {
       // Pre-tys uses MTD tax year format
       DownstreamUri[Unit](
         s"income-tax/income/employments/non-paye/${nino.nino}/${taxYear.asMtd}",
-        DownstreamStrategy.standardStrategy(employmentsAppConfig.api1661DownstreamConfig))
+        DownstreamStrategy.standardStrategy(employmentsAppConfig.api1661DownstreamConfig)
+      )
     }
 
     put(body = body, uri = uri)

--- a/app/v1/connectors/DeleteEmploymentFinancialDetailsConnector.scala
+++ b/app/v1/connectors/DeleteEmploymentFinancialDetailsConnector.scala
@@ -18,7 +18,7 @@ package v1.connectors
 
 import config.EmploymentsAppConfig
 import shared.config.SharedAppConfig
-import shared.connectors.DownstreamUri.TaxYearSpecificIfsUri
+import shared.connectors.DownstreamUri.IfsUri
 import shared.connectors._
 import shared.connectors.httpparsers.StandardDownstreamHttpParser.readsEmpty
 import uk.gov.hmrc.http.HeaderCarrier
@@ -29,7 +29,10 @@ import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class DeleteEmploymentFinancialDetailsConnector @Inject() (val http: HttpClientV2, val appConfig: SharedAppConfig, employmentsAppConfig: EmploymentsAppConfig) extends BaseDownstreamConnector {
+class DeleteEmploymentFinancialDetailsConnector @Inject() (val http: HttpClientV2,
+                                                           val appConfig: SharedAppConfig,
+                                                           employmentsAppConfig: EmploymentsAppConfig)
+    extends BaseDownstreamConnector {
 
   def deleteEmploymentFinancialDetails(request: DeleteEmploymentFinancialDetailsRequest)(implicit
       hc: HeaderCarrier,
@@ -39,7 +42,7 @@ class DeleteEmploymentFinancialDetailsConnector @Inject() (val http: HttpClientV
     import request._
 
     val downstreamUri = if (taxYear.useTaxYearSpecificApi) {
-      TaxYearSpecificIfsUri[Unit](
+      IfsUri[Unit](
         s"income-tax/${taxYear.asTysDownstream}/income/employments/$nino/${employmentId.value}"
       )
     } else {

--- a/app/v1/connectors/DeleteNonPayeEmploymentConnector.scala
+++ b/app/v1/connectors/DeleteNonPayeEmploymentConnector.scala
@@ -18,7 +18,7 @@ package v1.connectors
 
 import config.EmploymentsAppConfig
 import shared.config.SharedAppConfig
-import shared.connectors.DownstreamUri.TaxYearSpecificIfsUri
+import shared.connectors.DownstreamUri.IfsUri
 import shared.connectors.httpparsers.StandardDownstreamHttpParser.readsEmpty
 import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome, DownstreamStrategy, DownstreamUri}
 import uk.gov.hmrc.http.HeaderCarrier
@@ -29,7 +29,8 @@ import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class DeleteNonPayeEmploymentConnector @Inject() (val http: HttpClientV2, val appConfig: SharedAppConfig, employmentsAppConfig: EmploymentsAppConfig) extends BaseDownstreamConnector {
+class DeleteNonPayeEmploymentConnector @Inject() (val http: HttpClientV2, val appConfig: SharedAppConfig, employmentsAppConfig: EmploymentsAppConfig)
+    extends BaseDownstreamConnector {
 
   def deleteNonPayeEmployment(request: DeleteNonPayeEmploymentRequest)(implicit
       hc: HeaderCarrier,
@@ -39,7 +40,7 @@ class DeleteNonPayeEmploymentConnector @Inject() (val http: HttpClientV2, val ap
     import request._
 
     val downstreamUri = if (taxYear.useTaxYearSpecificApi) {
-      TaxYearSpecificIfsUri[Unit](
+      IfsUri[Unit](
         s"income-tax/employments/non-paye/${taxYear.asTysDownstream}/${nino.value}"
       )
     } else {

--- a/app/v1/connectors/IgnoreEmploymentConnector.scala
+++ b/app/v1/connectors/IgnoreEmploymentConnector.scala
@@ -17,7 +17,7 @@
 package v1.connectors
 
 import shared.config.{ConfigFeatureSwitches, SharedAppConfig}
-import shared.connectors.DownstreamUri.{HipUri, TaxYearSpecificIfsUri}
+import shared.connectors.DownstreamUri.{HipUri, IfsUri}
 import shared.connectors.httpparsers.StandardDownstreamHttpParser._
 import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome}
 import uk.gov.hmrc.http.HeaderCarrier
@@ -35,11 +35,12 @@ class IgnoreEmploymentConnector @Inject() (val http: HttpClientV2, val appConfig
 
     import request._
 
-    val downstreamUri =  if (ConfigFeatureSwitches().isEnabled("ifs_hip_migration_1940")) {
+    val downstreamUri = if (ConfigFeatureSwitches().isEnabled("ifs_hip_migration_1940")) {
       HipUri[Unit](s"itsd/income/ignore/employments/$nino/${employmentId.value}?taxYear=${taxYear.asTysDownstream}")
     } else {
-      TaxYearSpecificIfsUri[Unit](s"income-tax/${taxYear.asTysDownstream}/income/employments/$nino/${employmentId.value}/ignore")
+      IfsUri[Unit](s"income-tax/${taxYear.asTysDownstream}/income/employments/$nino/${employmentId.value}/ignore")
     }
     put(uri = downstreamUri, body = "")
   }
+
 }

--- a/app/v1/connectors/OtherEmploymentIncomeConnector.scala
+++ b/app/v1/connectors/OtherEmploymentIncomeConnector.scala
@@ -19,7 +19,7 @@ package v1.connectors
 import config.EmploymentsFeatureSwitches
 import play.api.http.Status.NO_CONTENT
 import shared.config.SharedAppConfig
-import shared.connectors.DownstreamUri.{DesUri, IfsUri, TaxYearSpecificIfsUri}
+import shared.connectors.DownstreamUri.{DesUri, IfsUri}
 import shared.connectors.httpparsers.StandardDownstreamHttpParser.{SuccessCode, reads, readsEmpty}
 import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome}
 import uk.gov.hmrc.http.HeaderCarrier
@@ -31,7 +31,8 @@ import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class OtherEmploymentIncomeConnector @Inject()(val http: HttpClientV2, val appConfig: SharedAppConfig)(implicit featureSwitches: EmploymentsFeatureSwitches)
+class OtherEmploymentIncomeConnector @Inject() (val http: HttpClientV2, val appConfig: SharedAppConfig)(implicit
+    featureSwitches: EmploymentsFeatureSwitches)
     extends BaseDownstreamConnector {
 
   def deleteOtherEmploymentIncome(request: DeleteOtherEmploymentIncomeRequest)(implicit
@@ -43,7 +44,7 @@ class OtherEmploymentIncomeConnector @Inject()(val http: HttpClientV2, val appCo
 
     val downstreamUri =
       if (request.taxYear.useTaxYearSpecificApi) {
-        TaxYearSpecificIfsUri[Unit](s"income-tax/income/other/employments/${request.taxYear.asTysDownstream}/${request.nino}")
+        IfsUri[Unit](s"income-tax/income/other/employments/${request.taxYear.asTysDownstream}/${request.nino}")
       } else if (featureSwitches.isDesIf_MigrationEnabled) {
         IfsUri[Unit](s"income-tax/${request.taxYear.asMtd}/income/other/employments/${request.nino}")
       } else {
@@ -61,8 +62,7 @@ class OtherEmploymentIncomeConnector @Inject()(val http: HttpClientV2, val appCo
       correlationId: String): Future[DownstreamOutcome[RetrieveOtherEmploymentResponse]] = {
 
     val resolvedDownstreamUri = if (request.taxYear.useTaxYearSpecificApi) {
-      TaxYearSpecificIfsUri[RetrieveOtherEmploymentResponse](
-        s"income-tax/income/other/employments/${request.taxYear.asTysDownstream}/${request.nino}")
+      IfsUri[RetrieveOtherEmploymentResponse](s"income-tax/income/other/employments/${request.taxYear.asTysDownstream}/${request.nino}")
     } else if (featureSwitches.isDesIf_MigrationEnabled) {
       IfsUri[RetrieveOtherEmploymentResponse](s"income-tax/${request.taxYear.asMtd}/income/other/employments/${request.nino}")
     } else {

--- a/app/v1/connectors/RetrieveEmploymentAndFinancialDetailsConnector.scala
+++ b/app/v1/connectors/RetrieveEmploymentAndFinancialDetailsConnector.scala
@@ -18,7 +18,7 @@ package v1.connectors
 
 import config.EmploymentsAppConfig
 import shared.config.{ConfigFeatureSwitches, SharedAppConfig}
-import shared.connectors.DownstreamUri.{HipUri, TaxYearSpecificIfsUri}
+import shared.connectors.DownstreamUri.{HipUri, IfsUri}
 import shared.connectors.httpparsers.StandardDownstreamHttpParser.reads
 import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome, DownstreamStrategy, DownstreamUri}
 import uk.gov.hmrc.http.HeaderCarrier
@@ -30,7 +30,10 @@ import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class RetrieveEmploymentAndFinancialDetailsConnector @Inject() (val http: HttpClientV2, val appConfig: SharedAppConfig, employmentsAppConfig: EmploymentsAppConfig) extends BaseDownstreamConnector {
+class RetrieveEmploymentAndFinancialDetailsConnector @Inject() (val http: HttpClientV2,
+                                                                val appConfig: SharedAppConfig,
+                                                                employmentsAppConfig: EmploymentsAppConfig)
+    extends BaseDownstreamConnector {
 
   def retrieve(request: RetrieveEmploymentAndFinancialDetailsRequest)(implicit
       hc: HeaderCarrier,
@@ -48,7 +51,7 @@ class RetrieveEmploymentAndFinancialDetailsConnector @Inject() (val http: HttpCl
           s"itsa/income-tax/v1/${taxYear.asTysDownstream}/income/employments/${nino.value}/${employmentId.value}"
         )
       } else {
-        TaxYearSpecificIfsUri[RetrieveEmploymentAndFinancialDetailsResponse](
+        IfsUri[RetrieveEmploymentAndFinancialDetailsResponse](
           s"income-tax/income/employments/${taxYear.asTysDownstream}/${nino.value}/${employmentId.value}"
         )
       }

--- a/app/v1/connectors/RetrieveNonPayeEmploymentConnector.scala
+++ b/app/v1/connectors/RetrieveNonPayeEmploymentConnector.scala
@@ -18,7 +18,7 @@ package v1.connectors
 
 import config.EmploymentsAppConfig
 import shared.config.SharedAppConfig
-import shared.connectors.DownstreamUri.TaxYearSpecificIfsUri
+import shared.connectors.DownstreamUri.IfsUri
 import shared.connectors.httpparsers.StandardDownstreamHttpParser.reads
 import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome, DownstreamStrategy, DownstreamUri}
 import uk.gov.hmrc.http.HeaderCarrier
@@ -30,7 +30,10 @@ import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class RetrieveNonPayeEmploymentConnector @Inject() (val http: HttpClientV2, val appConfig: SharedAppConfig, employmentsAppConfig: EmploymentsAppConfig) extends BaseDownstreamConnector {
+class RetrieveNonPayeEmploymentConnector @Inject() (val http: HttpClientV2,
+                                                    val appConfig: SharedAppConfig,
+                                                    employmentsAppConfig: EmploymentsAppConfig)
+    extends BaseDownstreamConnector {
 
   def retrieveNonPayeEmployment(request: RetrieveNonPayeEmploymentIncomeRequest)(implicit
       hc: HeaderCarrier,
@@ -40,7 +43,7 @@ class RetrieveNonPayeEmploymentConnector @Inject() (val http: HttpClientV2, val 
     import request._
 
     val downstreamUri = if (taxYear.useTaxYearSpecificApi) {
-      TaxYearSpecificIfsUri[RetrieveNonPayeEmploymentIncomeResponse](
+      IfsUri[RetrieveNonPayeEmploymentIncomeResponse](
         s"income-tax/income/employments/non-paye/${taxYear.asTysDownstream}/${nino.value}?view=${source.toDesViewString}"
       )
     } else {

--- a/app/v1/connectors/UnignoreEmploymentConnector.scala
+++ b/app/v1/connectors/UnignoreEmploymentConnector.scala
@@ -17,7 +17,7 @@
 package v1.connectors
 
 import shared.config.{ConfigFeatureSwitches, SharedAppConfig}
-import shared.connectors.DownstreamUri.{HipUri, TaxYearSpecificIfsUri}
+import shared.connectors.DownstreamUri.{HipUri, IfsUri}
 import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.client.HttpClientV2
@@ -38,10 +38,10 @@ class UnignoreEmploymentConnector @Inject() (val http: HttpClientV2, val appConf
     import shared.connectors.httpparsers.StandardDownstreamHttpParser._
 
     val downstreamUri =
-      if(ConfigFeatureSwitches().isEnabled("ifs_hip_migration_1800")) {
+      if (ConfigFeatureSwitches().isEnabled("ifs_hip_migration_1800")) {
         HipUri[Unit](s"itsd/income/ignore/employments/$nino/${employmentId.value}?taxYear=${taxYear.asTysDownstream}")
       } else {
-        TaxYearSpecificIfsUri[Unit](s"income-tax/${taxYear.asTysDownstream}/employments/$nino/ignore/${employmentId.value}")
+        IfsUri[Unit](s"income-tax/${taxYear.asTysDownstream}/employments/$nino/ignore/${employmentId.value}")
       }
 
     delete(downstreamUri)

--- a/app/v2/connectors/AmendFinancialDetailsConnector.scala
+++ b/app/v2/connectors/AmendFinancialDetailsConnector.scala
@@ -19,7 +19,7 @@ package v2.connectors
 import config.EmploymentsAppConfig
 import play.api.libs.json.Format.GenericFormat
 import shared.config.SharedAppConfig
-import shared.connectors.DownstreamUri.TaxYearSpecificIfsUri
+import shared.connectors.DownstreamUri.IfsUri
 import shared.connectors.httpparsers.StandardDownstreamHttpParser.readsEmpty
 import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome, DownstreamStrategy, DownstreamUri}
 import uk.gov.hmrc.http.HeaderCarrier
@@ -30,7 +30,8 @@ import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class AmendFinancialDetailsConnector @Inject() (val http: HttpClientV2, val appConfig: SharedAppConfig, employmentsAppConfig: EmploymentsAppConfig) extends BaseDownstreamConnector {
+class AmendFinancialDetailsConnector @Inject() (val http: HttpClientV2, val appConfig: SharedAppConfig, employmentsAppConfig: EmploymentsAppConfig)
+    extends BaseDownstreamConnector {
 
   def amendFinancialDetails(request: AmendFinancialDetailsRequest)(implicit
       hc: HeaderCarrier,
@@ -41,11 +42,12 @@ class AmendFinancialDetailsConnector @Inject() (val http: HttpClientV2, val appC
 
     val downstreamUri =
       if (taxYear.useTaxYearSpecificApi) {
-        TaxYearSpecificIfsUri[Unit](s"income-tax/${taxYear.asTysDownstream}/income/employments/$nino/${employmentId.value}")
+        IfsUri[Unit](s"income-tax/${taxYear.asTysDownstream}/income/employments/$nino/${employmentId.value}")
       } else {
-          DownstreamUri[Unit](s"income-tax/income/employments/$nino/${taxYear.asMtd}/${employmentId.value}",
-            DownstreamStrategy.standardStrategy(employmentsAppConfig.release6DownstreamConfig)
-          )
+        DownstreamUri[Unit](
+          s"income-tax/income/employments/$nino/${taxYear.asMtd}/${employmentId.value}",
+          DownstreamStrategy.standardStrategy(employmentsAppConfig.release6DownstreamConfig)
+        )
       }
 
     put(body, downstreamUri)

--- a/app/v2/connectors/AmendOtherEmploymentConnector.scala
+++ b/app/v2/connectors/AmendOtherEmploymentConnector.scala
@@ -17,7 +17,7 @@
 package v2.connectors
 
 import shared.config.SharedAppConfig
-import shared.connectors.DownstreamUri.{DesUri, TaxYearSpecificIfsUri}
+import shared.connectors.DownstreamUri.{DesUri, IfsUri}
 import shared.connectors.httpparsers.StandardDownstreamHttpParser.readsEmpty
 import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome}
 import uk.gov.hmrc.http.HeaderCarrier
@@ -38,7 +38,7 @@ class AmendOtherEmploymentConnector @Inject() (val http: HttpClientV2, val appCo
     import request._
 
     val downstreamUri = if (taxYear.useTaxYearSpecificApi) {
-      TaxYearSpecificIfsUri[Unit](s"income-tax/income/other/employments/${taxYear.asTysDownstream}/${nino.nino}")
+      IfsUri[Unit](s"income-tax/income/other/employments/${taxYear.asTysDownstream}/${nino.nino}")
     } else {
       DesUri[Unit](s"income-tax/income/other/employments/${nino.nino}/${taxYear.asMtd}")
     }

--- a/app/v2/connectors/CreateAmendNonPayeEmploymentConnector.scala
+++ b/app/v2/connectors/CreateAmendNonPayeEmploymentConnector.scala
@@ -18,7 +18,7 @@ package v2.connectors
 
 import config.EmploymentsAppConfig
 import shared.config.SharedAppConfig
-import shared.connectors.DownstreamUri.TaxYearSpecificIfsUri
+import shared.connectors.DownstreamUri.IfsUri
 import shared.connectors._
 import shared.connectors.httpparsers.StandardDownstreamHttpParser.readsEmpty
 import uk.gov.hmrc.http.HeaderCarrier
@@ -29,7 +29,10 @@ import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class CreateAmendNonPayeEmploymentConnector @Inject() (val http: HttpClientV2, val appConfig: SharedAppConfig, employmentsAppConfig: EmploymentsAppConfig) extends BaseDownstreamConnector {
+class CreateAmendNonPayeEmploymentConnector @Inject() (val http: HttpClientV2,
+                                                       val appConfig: SharedAppConfig,
+                                                       employmentsAppConfig: EmploymentsAppConfig)
+    extends BaseDownstreamConnector {
 
   def createAndAmend(request: CreateAmendNonPayeEmploymentRequest)(implicit
       hc: HeaderCarrier,
@@ -39,12 +42,13 @@ class CreateAmendNonPayeEmploymentConnector @Inject() (val http: HttpClientV2, v
     import request._
 
     val uri = if (taxYear.useTaxYearSpecificApi) {
-      TaxYearSpecificIfsUri[Unit](s"income-tax/income/employments/non-paye/${taxYear.asTysDownstream}/${nino.nino}")
+      IfsUri[Unit](s"income-tax/income/employments/non-paye/${taxYear.asTysDownstream}/${nino.nino}")
     } else {
       // Pre-tys uses MTD tax year format
       DownstreamUri[Unit](
         s"income-tax/income/employments/non-paye/${nino.nino}/${taxYear.asMtd}",
-        DownstreamStrategy.standardStrategy(employmentsAppConfig.api1661DownstreamConfig))
+        DownstreamStrategy.standardStrategy(employmentsAppConfig.api1661DownstreamConfig)
+      )
     }
 
     put(body = body, uri = uri)

--- a/app/v2/connectors/DeleteEmploymentFinancialDetailsConnector.scala
+++ b/app/v2/connectors/DeleteEmploymentFinancialDetailsConnector.scala
@@ -18,7 +18,7 @@ package v2.connectors
 
 import config.EmploymentsAppConfig
 import shared.config.SharedAppConfig
-import shared.connectors.DownstreamUri.TaxYearSpecificIfsUri
+import shared.connectors.DownstreamUri.IfsUri
 import shared.connectors.httpparsers.StandardDownstreamHttpParser.readsEmpty
 import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome, DownstreamStrategy, DownstreamUri}
 import uk.gov.hmrc.http.HeaderCarrier
@@ -29,7 +29,10 @@ import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class DeleteEmploymentFinancialDetailsConnector @Inject() (val http: HttpClientV2, val appConfig: SharedAppConfig, employmentsAppConfig: EmploymentsAppConfig) extends BaseDownstreamConnector {
+class DeleteEmploymentFinancialDetailsConnector @Inject() (val http: HttpClientV2,
+                                                           val appConfig: SharedAppConfig,
+                                                           employmentsAppConfig: EmploymentsAppConfig)
+    extends BaseDownstreamConnector {
 
   def deleteEmploymentFinancialDetails(request: DeleteEmploymentFinancialDetailsRequest)(implicit
       hc: HeaderCarrier,
@@ -39,7 +42,7 @@ class DeleteEmploymentFinancialDetailsConnector @Inject() (val http: HttpClientV
     import request._
 
     val downstreamUri = if (taxYear.useTaxYearSpecificApi) {
-      TaxYearSpecificIfsUri[Unit](
+      IfsUri[Unit](
         s"income-tax/${taxYear.asTysDownstream}/income/employments/$nino/${employmentId.value}"
       )
     } else {

--- a/app/v2/connectors/DeleteNonPayeEmploymentConnector.scala
+++ b/app/v2/connectors/DeleteNonPayeEmploymentConnector.scala
@@ -18,7 +18,7 @@ package v2.connectors
 
 import config.EmploymentsAppConfig
 import shared.config.SharedAppConfig
-import shared.connectors.DownstreamUri.TaxYearSpecificIfsUri
+import shared.connectors.DownstreamUri.IfsUri
 import shared.connectors.httpparsers.StandardDownstreamHttpParser.readsEmpty
 import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome, DownstreamStrategy, DownstreamUri}
 import uk.gov.hmrc.http.HeaderCarrier
@@ -29,7 +29,8 @@ import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class DeleteNonPayeEmploymentConnector @Inject() (val http: HttpClientV2, val appConfig: SharedAppConfig, employmentsAppConfig: EmploymentsAppConfig) extends BaseDownstreamConnector {
+class DeleteNonPayeEmploymentConnector @Inject() (val http: HttpClientV2, val appConfig: SharedAppConfig, employmentsAppConfig: EmploymentsAppConfig)
+    extends BaseDownstreamConnector {
 
   def deleteNonPayeEmployment(request: DeleteNonPayeEmploymentRequest)(implicit
       hc: HeaderCarrier,
@@ -39,7 +40,7 @@ class DeleteNonPayeEmploymentConnector @Inject() (val http: HttpClientV2, val ap
     import request._
 
     val downstreamUri = if (taxYear.useTaxYearSpecificApi) {
-      TaxYearSpecificIfsUri[Unit](
+      IfsUri[Unit](
         s"income-tax/employments/non-paye/${taxYear.asTysDownstream}/${nino.value}"
       )
     } else {

--- a/app/v2/connectors/IgnoreEmploymentConnector.scala
+++ b/app/v2/connectors/IgnoreEmploymentConnector.scala
@@ -17,7 +17,7 @@
 package v2.connectors
 
 import shared.config.{ConfigFeatureSwitches, SharedAppConfig}
-import shared.connectors.DownstreamUri.{HipUri, TaxYearSpecificIfsUri}
+import shared.connectors.DownstreamUri.{HipUri, IfsUri}
 import shared.connectors.httpparsers.StandardDownstreamHttpParser._
 import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome}
 import uk.gov.hmrc.http.HeaderCarrier
@@ -35,11 +35,12 @@ class IgnoreEmploymentConnector @Inject() (val http: HttpClientV2, val appConfig
 
     import request._
 
-    val downstreamUri =  if (ConfigFeatureSwitches().isEnabled("ifs_hip_migration_1940")) {
+    val downstreamUri = if (ConfigFeatureSwitches().isEnabled("ifs_hip_migration_1940")) {
       HipUri[Unit](s"itsd/income/ignore/employments/$nino/${employmentId.value}?taxYear=${taxYear.asTysDownstream}")
     } else {
-      TaxYearSpecificIfsUri[Unit](s"income-tax/${taxYear.asTysDownstream}/income/employments/$nino/${employmentId.value}/ignore")
+      IfsUri[Unit](s"income-tax/${taxYear.asTysDownstream}/income/employments/$nino/${employmentId.value}/ignore")
     }
     put(uri = downstreamUri, body = "")
   }
+
 }

--- a/app/v2/connectors/OtherEmploymentIncomeConnector.scala
+++ b/app/v2/connectors/OtherEmploymentIncomeConnector.scala
@@ -19,7 +19,7 @@ package v2.connectors
 import config.EmploymentsFeatureSwitches
 import play.api.http.Status.NO_CONTENT
 import shared.config.SharedAppConfig
-import shared.connectors.DownstreamUri.{DesUri, IfsUri, TaxYearSpecificIfsUri}
+import shared.connectors.DownstreamUri.{DesUri, IfsUri}
 import shared.connectors.httpparsers.StandardDownstreamHttpParser.{SuccessCode, reads, readsEmpty}
 import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome}
 import uk.gov.hmrc.http.HeaderCarrier
@@ -31,7 +31,8 @@ import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class OtherEmploymentIncomeConnector @Inject()(val http: HttpClientV2, val appConfig: SharedAppConfig)(implicit featureSwitches: EmploymentsFeatureSwitches)
+class OtherEmploymentIncomeConnector @Inject() (val http: HttpClientV2, val appConfig: SharedAppConfig)(implicit
+    featureSwitches: EmploymentsFeatureSwitches)
     extends BaseDownstreamConnector {
 
   def deleteOtherEmploymentIncome(request: DeleteOtherEmploymentIncomeRequest)(implicit
@@ -43,7 +44,7 @@ class OtherEmploymentIncomeConnector @Inject()(val http: HttpClientV2, val appCo
 
     val downstreamUri =
       if (request.taxYear.useTaxYearSpecificApi) {
-        TaxYearSpecificIfsUri[Unit](s"income-tax/income/other/employments/${request.taxYear.asTysDownstream}/${request.nino}")
+        IfsUri[Unit](s"income-tax/income/other/employments/${request.taxYear.asTysDownstream}/${request.nino}")
       } else if (featureSwitches.isDesIf_MigrationEnabled) {
         IfsUri[Unit](s"income-tax/${request.taxYear.asMtd}/income/other/employments/${request.nino}")
       } else {
@@ -61,8 +62,7 @@ class OtherEmploymentIncomeConnector @Inject()(val http: HttpClientV2, val appCo
       correlationId: String): Future[DownstreamOutcome[RetrieveOtherEmploymentResponse]] = {
 
     val resolvedDownstreamUri = if (request.taxYear.useTaxYearSpecificApi) {
-      TaxYearSpecificIfsUri[RetrieveOtherEmploymentResponse](
-        s"income-tax/income/other/employments/${request.taxYear.asTysDownstream}/${request.nino}")
+      IfsUri[RetrieveOtherEmploymentResponse](s"income-tax/income/other/employments/${request.taxYear.asTysDownstream}/${request.nino}")
     } else if (featureSwitches.isDesIf_MigrationEnabled) {
       IfsUri[RetrieveOtherEmploymentResponse](s"income-tax/${request.taxYear.asMtd}/income/other/employments/${request.nino}")
     } else {

--- a/app/v2/connectors/RetrieveEmploymentAndFinancialDetailsConnector.scala
+++ b/app/v2/connectors/RetrieveEmploymentAndFinancialDetailsConnector.scala
@@ -18,7 +18,7 @@ package v2.connectors
 
 import config.EmploymentsAppConfig
 import shared.config.{ConfigFeatureSwitches, SharedAppConfig}
-import shared.connectors.DownstreamUri.{HipUri, TaxYearSpecificIfsUri}
+import shared.connectors.DownstreamUri.{HipUri, IfsUri}
 import shared.connectors.httpparsers.StandardDownstreamHttpParser.reads
 import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome, DownstreamStrategy, DownstreamUri}
 import uk.gov.hmrc.http.HeaderCarrier
@@ -30,7 +30,10 @@ import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class RetrieveEmploymentAndFinancialDetailsConnector @Inject() (val http: HttpClientV2, val appConfig: SharedAppConfig, employmentsAppConfig: EmploymentsAppConfig) extends BaseDownstreamConnector {
+class RetrieveEmploymentAndFinancialDetailsConnector @Inject() (val http: HttpClientV2,
+                                                                val appConfig: SharedAppConfig,
+                                                                employmentsAppConfig: EmploymentsAppConfig)
+    extends BaseDownstreamConnector {
 
   def retrieve(request: RetrieveEmploymentAndFinancialDetailsRequest)(implicit
       hc: HeaderCarrier,
@@ -48,7 +51,7 @@ class RetrieveEmploymentAndFinancialDetailsConnector @Inject() (val http: HttpCl
           s"itsa/income-tax/v1/${taxYear.asTysDownstream}/income/employments/${nino.value}/${employmentId.value}"
         )
       } else {
-        TaxYearSpecificIfsUri[RetrieveEmploymentAndFinancialDetailsResponse](
+        IfsUri[RetrieveEmploymentAndFinancialDetailsResponse](
           s"income-tax/income/employments/${taxYear.asTysDownstream}/${nino.value}/${employmentId.value}"
         )
       }

--- a/app/v2/connectors/RetrieveNonPayeEmploymentConnector.scala
+++ b/app/v2/connectors/RetrieveNonPayeEmploymentConnector.scala
@@ -18,7 +18,7 @@ package v2.connectors
 
 import config.EmploymentsAppConfig
 import shared.config.SharedAppConfig
-import shared.connectors.DownstreamUri.TaxYearSpecificIfsUri
+import shared.connectors.DownstreamUri.IfsUri
 import shared.connectors.httpparsers.StandardDownstreamHttpParser.reads
 import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome, DownstreamStrategy, DownstreamUri}
 import uk.gov.hmrc.http.HeaderCarrier
@@ -30,7 +30,10 @@ import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class RetrieveNonPayeEmploymentConnector @Inject() (val http: HttpClientV2, val appConfig: SharedAppConfig, employmentsAppConfig: EmploymentsAppConfig) extends BaseDownstreamConnector {
+class RetrieveNonPayeEmploymentConnector @Inject() (val http: HttpClientV2,
+                                                    val appConfig: SharedAppConfig,
+                                                    employmentsAppConfig: EmploymentsAppConfig)
+    extends BaseDownstreamConnector {
 
   def retrieveNonPayeEmployment(request: RetrieveNonPayeEmploymentIncomeRequest)(implicit
       hc: HeaderCarrier,
@@ -40,7 +43,7 @@ class RetrieveNonPayeEmploymentConnector @Inject() (val http: HttpClientV2, val 
     import request._
 
     val downstreamUri = if (taxYear.useTaxYearSpecificApi) {
-      TaxYearSpecificIfsUri[RetrieveNonPayeEmploymentIncomeResponse](
+      IfsUri[RetrieveNonPayeEmploymentIncomeResponse](
         s"income-tax/income/employments/non-paye/${taxYear.asTysDownstream}/${nino.value}?view=${source.toDesViewString}"
       )
     } else {

--- a/app/v2/connectors/UnignoreEmploymentConnector.scala
+++ b/app/v2/connectors/UnignoreEmploymentConnector.scala
@@ -17,7 +17,7 @@
 package v2.connectors
 
 import shared.config.{ConfigFeatureSwitches, SharedAppConfig}
-import shared.connectors.DownstreamUri.{HipUri, TaxYearSpecificIfsUri}
+import shared.connectors.DownstreamUri.{HipUri, IfsUri}
 import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.client.HttpClientV2
@@ -38,10 +38,10 @@ class UnignoreEmploymentConnector @Inject() (val http: HttpClientV2, val appConf
     import shared.connectors.httpparsers.StandardDownstreamHttpParser._
 
     val downstreamUri =
-      if(ConfigFeatureSwitches().isEnabled("ifs_hip_migration_1800")) {
+      if (ConfigFeatureSwitches().isEnabled("ifs_hip_migration_1800")) {
         HipUri[Unit](s"itsd/income/ignore/employments/$nino/${employmentId.value}?taxYear=${taxYear.asTysDownstream}")
       } else {
-        TaxYearSpecificIfsUri[Unit](s"income-tax/${taxYear.asTysDownstream}/employments/$nino/ignore/${employmentId.value}")
+        IfsUri[Unit](s"income-tax/${taxYear.asTysDownstream}/employments/$nino/ignore/${employmentId.value}")
       }
 
     delete(downstreamUri)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -185,14 +185,6 @@ microservice {
       environmentHeaders = ["Accept", "Gov-Test-Scenario", "Location", "X-Request-Timestamp", "X-Session-Id", "X-Request-Id"]
     }
 
-    tys-ifs {
-      host = 127.0.0.1
-      port = 9772
-      env = Prod
-      token = ABCD1234
-      environmentHeaders = ["Accept", "Gov-Test-Scenario", "Content-Type", "Location", "X-Request-Timestamp", "X-Session-Id", "X-Request-Id"]
-    }
-
     release6 {
       host = 127.0.0.1
       port = 9772

--- a/it/test/shared/support/IntegrationBaseSpec.scala
+++ b/it/test/shared/support/IntegrationBaseSpec.scala
@@ -35,8 +35,6 @@ trait IntegrationBaseSpec extends UnitSpec with WireMockHelper with GuiceOneServ
     "microservice.services.des.port"           -> mockPort,
     "microservice.services.ifs.host"           -> mockHost,
     "microservice.services.ifs.port"           -> mockPort,
-    "microservice.services.tys-ifs.host"       -> mockHost,
-    "microservice.services.tys-ifs.port"       -> mockPort,
     "microservice.services.hip.host"           -> mockHost,
     "microservice.services.hip.port"           -> mockPort,
     "microservice.services.mtd-id-lookup.host" -> mockHost,

--- a/test/shared/config/MockSharedAppConfig.scala
+++ b/test/shared/config/MockSharedAppConfig.scala
@@ -33,7 +33,6 @@ trait MockSharedAppConfig extends TestSuite with MockFactory {
 
     def desDownstreamConfig: CallHandler0[DownstreamConfig]    = (() => mockSharedAppConfig.desDownstreamConfig: DownstreamConfig).expects()
     def ifsDownstreamConfig: CallHandler0[DownstreamConfig]    = (() => mockSharedAppConfig.ifsDownstreamConfig: DownstreamConfig).expects()
-    def tysIfsDownstreamConfig: CallHandler0[DownstreamConfig] = (() => mockSharedAppConfig.tysIfsDownstreamConfig: DownstreamConfig).expects()
 
     def hipDownstreamConfig: CallHandler[BasicAuthDownstreamConfig] = (() => mockSharedAppConfig.hipDownstreamConfig: BasicAuthDownstreamConfig).expects()
 

--- a/test/shared/config/SharedAppConfigSpec.scala
+++ b/test/shared/config/SharedAppConfigSpec.scala
@@ -73,22 +73,6 @@ class SharedAppConfigSpec extends UnitSpec {
         expectedIfsEnvHeaders
       )
     }
-
-    "return the TYS-IFS config" in {
-      val expectedTysIfsEnvHeaders = Some(
-        List(
-          "TYS-IFS-Accept",
-          "TYS-IFS-Gov-Test-Scenario",
-          "TYS-IFS-Content-Type"
-        ))
-
-      simpleAppConfig.tysIfsDownstreamConfig shouldBe DownstreamConfig(
-        "http://127.0.0.1:8888",
-        "Prod",
-        "TYS-IFS-ABCD1234",
-        expectedTysIfsEnvHeaders
-      )
-    }
   }
 
   "endpointsEnabled" when {
@@ -345,14 +329,6 @@ class SharedAppConfigSpec extends UnitSpec {
           |        env = Prod
           |        token = IFS-ABCD1234
           |        environmentHeaders = ["IFS-Accept", "IFS-Gov-Test-Scenario", "IFS-Content-Type"]
-          |      }
-          |
-          |      tys-ifs {
-          |        host = 127.0.0.1
-          |        port = 8888
-          |        env = Prod
-          |        token = TYS-IFS-ABCD1234
-          |        environmentHeaders = ["TYS-IFS-Accept", "TYS-IFS-Gov-Test-Scenario", "TYS-IFS-Content-Type"]
           |      }
           |    }
           |  }

--- a/test/shared/config/rewriters/EndpointSummaryRewriterSpec.scala
+++ b/test/shared/config/rewriters/EndpointSummaryRewriterSpec.scala
@@ -62,13 +62,13 @@ class EndpointSummaryRewriterSpec extends UnitSpec with MockSharedAppConfig {
       }
 
       "return the rewritten summary when it contains parentheses" in {
-        val result = rewrite("", "", "summary: Create and Amend CGT Residential Property Disposals (non-PPD)")
-        result shouldBe """summary: "Create and Amend CGT Residential Property Disposals (non-PPD) [test only]""""
+        val result = rewrite("", "", "summary: Create and Amend employment expenses (parentheses)")
+        result shouldBe """summary: "Create and Amend employment expenses (parentheses) [test only]""""
       }
 
       "return the rewritten summary when it contains square brackets" in {
-        val result = rewrite("", "", "summary: Create and Amend CGT Residential Property Disposals [non-PPD]")
-        result shouldBe """summary: "Create and Amend CGT Residential Property Disposals [non-PPD] [test only]""""
+        val result = rewrite("", "", "summary: Create and Amend employment expenses [square-brackets]")
+        result shouldBe """summary: "Create and Amend employment expenses [square-brackets] [test only]""""
       }
     }
 

--- a/test/shared/connectors/ConnectorSpec.scala
+++ b/test/shared/connectors/ConnectorSpec.scala
@@ -132,12 +132,6 @@ trait ConnectorSpec extends UnitSpec with Status with MimeTypes with HeaderNames
     MockedSharedAppConfig.ifsDownstreamConfig.anyNumberOfTimes() returns config
   }
 
-  protected trait TysIfsTest extends StandardConnectorTest {
-    override val name = "tys-ifs"
-
-    MockedSharedAppConfig.tysIfsDownstreamConfig.anyNumberOfTimes() returns config
-  }
-
   protected trait HipTest extends ConnectorTest {
     private val clientId     = "clientId"
     private val clientSecret = "clientSecret"

--- a/test/v1/connectors/AmendFinancialDetailsConnectorSpec.scala
+++ b/test/v1/connectors/AmendFinancialDetailsConnectorSpec.scala
@@ -46,7 +46,7 @@ class AmendFinancialDetailsConnectorSpec extends EmploymentsConnectorSpec {
 
       }
 
-      "a valid request is submitted for a TYS tax year" in new TysIfsTest with MockEmploymentsAppConfig with Test {
+      "a valid request is submitted for a TYS tax year" in new IfsTest with MockEmploymentsAppConfig with Test {
         def taxYear = TaxYear.fromMtd("2023-24")
 
         val outcome = Right(ResponseWrapper(correlationId, ()))

--- a/test/v1/connectors/AmendOtherEmploymentConnectorSpec.scala
+++ b/test/v1/connectors/AmendOtherEmploymentConnectorSpec.scala
@@ -31,7 +31,7 @@ class AmendOtherEmploymentConnectorSpec extends ConnectorSpec {
     "return the expected response for a non-TYS request" when {
       "a valid request is made" in new DesTest with Test {
         def taxYear: TaxYear = TaxYear.fromMtd("2019-20")
-        val outcome = Right(ResponseWrapper(correlationId, ()))
+        val outcome          = Right(ResponseWrapper(correlationId, ()))
 
         willPut(
           url = url"$baseUrl/income-tax/income/other/employments/$nino/2019-20",
@@ -68,9 +68,9 @@ class AmendOtherEmploymentConnectorSpec extends ConnectorSpec {
       }
     }
     "return the expected response for a TYS request" when {
-      "a valid request is made" in new TysIfsTest with Test {
+      "a valid request is made" in new IfsTest with Test {
         def taxYear: TaxYear = TaxYear.fromMtd("2023-24")
-        val outcome = Right(ResponseWrapper(correlationId, ()))
+        val outcome          = Right(ResponseWrapper(correlationId, ()))
 
         willPut(
           url = url"$baseUrl/income-tax/income/other/employments/23-24/$nino",

--- a/test/v1/connectors/CreateAmendNonPayeEmploymentConnectorSpec.scala
+++ b/test/v1/connectors/CreateAmendNonPayeEmploymentConnectorSpec.scala
@@ -62,7 +62,7 @@ class CreateAmendNonPayeEmploymentConnectorSpec extends EmploymentsConnectorSpec
         await(connector.createAndAmend(request)) shouldBe outcome
       }
 
-      "a valid request is made for a TYS tax year" in new MockEmploymentsAppConfig with TysIfsTest with Test {
+      "a valid request is made for a TYS tax year" in new MockEmploymentsAppConfig with IfsTest with Test {
         val taxYear: TaxYear = TaxYear.fromMtd("2023-24")
 
         val outcome: Right[Nothing, ResponseWrapper[Unit]] = Right(ResponseWrapper(correlationId, ()))

--- a/test/v1/connectors/DeleteEmploymentFinancialDetailsConnectorSpec.scala
+++ b/test/v1/connectors/DeleteEmploymentFinancialDetailsConnectorSpec.scala
@@ -32,7 +32,7 @@ class DeleteEmploymentFinancialDetailsConnectorSpec extends EmploymentsConnector
     "return the expected response for a non-TYS request" when {
       "a valid request is made" in new Release6Test with Test {
         def taxYear: TaxYear = TaxYear.fromMtd("2019-20")
-        val outcome = Right(ResponseWrapper(correlationId, ()))
+        val outcome          = Right(ResponseWrapper(correlationId, ()))
 
         willDelete(
           url = url"$baseUrl/income-tax/income/employments/$nino/2019-20/$employmentId"
@@ -43,9 +43,9 @@ class DeleteEmploymentFinancialDetailsConnectorSpec extends EmploymentsConnector
     }
 
     "return the expected response for a TYS request" when {
-      "a valid request is made" in new MockEmploymentsAppConfig with TysIfsTest with Test {
+      "a valid request is made" in new MockEmploymentsAppConfig with IfsTest with Test {
         def taxYear: TaxYear = TaxYear.fromMtd("2023-24")
-        val outcome = Right(ResponseWrapper(correlationId, ()))
+        val outcome          = Right(ResponseWrapper(correlationId, ()))
 
         willDelete(
           url = url"$baseUrl/income-tax/23-24/income/employments/$nino/$employmentId"
@@ -61,7 +61,7 @@ class DeleteEmploymentFinancialDetailsConnectorSpec extends EmploymentsConnector
 
     def taxYear: TaxYear
 
-    protected val nino: String = "AA111111A"
+    protected val nino: String         = "AA111111A"
     protected val employmentId: String = "4557ecb5-fd32-48cc-81f5-e6acd1099f3c"
 
     protected val request: DeleteEmploymentFinancialDetailsRequest =

--- a/test/v1/connectors/DeleteNonPayeEmploymentConnectorSpec.scala
+++ b/test/v1/connectors/DeleteNonPayeEmploymentConnectorSpec.scala
@@ -45,7 +45,7 @@ class DeleteNonPayeEmploymentConnectorSpec extends EmploymentsConnectorSpec {
     }
 
     "deleteNonPayeEmployment is called for a TaxYearSpecific tax year" must {
-      "return a 200 for success scenario" in new MockEmploymentsAppConfig with TysIfsTest with Test {
+      "return a 200 for success scenario" in new MockEmploymentsAppConfig with IfsTest with Test {
         def taxYear: TaxYear = TaxYear.fromMtd("2023-24")
 
         val outcome = Right(ResponseWrapper(correlationId, ()))
@@ -63,10 +63,7 @@ class DeleteNonPayeEmploymentConnectorSpec extends EmploymentsConnectorSpec {
     def taxYear: TaxYear
 
     protected val connector: DeleteNonPayeEmploymentConnector =
-      new DeleteNonPayeEmploymentConnector(
-        http = mockHttpClient,
-        appConfig = mockSharedAppConfig,
-        employmentsAppConfig = mockEmploymentsConfig)
+      new DeleteNonPayeEmploymentConnector(http = mockHttpClient, appConfig = mockSharedAppConfig, employmentsAppConfig = mockEmploymentsConfig)
 
     protected val request: DeleteNonPayeEmploymentRequest =
       DeleteNonPayeEmploymentRequest(Nino("AA111111A"), taxYear = taxYear)

--- a/test/v1/connectors/IgnoreEmploymentConnectorSpec.scala
+++ b/test/v1/connectors/IgnoreEmploymentConnectorSpec.scala
@@ -28,7 +28,7 @@ import scala.concurrent.Future
 
 class IgnoreEmploymentConnectorSpec extends ConnectorSpec {
 
-  val nino: String = "AA111111A"
+  val nino: String         = "AA111111A"
   val employmentId: String = "4557ecb5-fd32-48cc-81f5-e6acd1099f3c"
 
   trait Test { _: ConnectorTest =>
@@ -50,7 +50,7 @@ class IgnoreEmploymentConnectorSpec extends ConnectorSpec {
 
   "ignoreEmployment" when {
     "given a valid request" should {
-      "return a success response when feature switch is disabled(IFS enabled)" in new TysIfsTest with Test with ConnectorTest {
+      "return a success response when feature switch is disabled(IFS enabled)" in new IfsTest with Test with ConnectorTest {
         MockedSharedAppConfig.featureSwitchConfig returns Configuration("ifs_hip_migration_1940.enabled" -> false)
         willPut(
           url = url"$baseUrl/income-tax/21-22/income/employments/$nino/$employmentId/ignore",

--- a/test/v1/connectors/OtherEmploymentIncomeConnectorSpec.scala
+++ b/test/v1/connectors/OtherEmploymentIncomeConnectorSpec.scala
@@ -45,37 +45,34 @@ class OtherEmploymentIncomeConnectorSpec extends ConnectorSpec with MockFeatureS
 
   "OtherEmploymentIncomeConnector" should {
     "return a 200 result on delete" when {
-      "the downstream call is successful, not tax year specific and 'isDesIf_MigrationEnabled' is off" in new DesTest
-      with Test with ConnectorTest {
+      "the downstream call is successful, not tax year specific and 'isDesIf_MigrationEnabled' is off" in new DesTest with Test with ConnectorTest {
         MockFeatureSwitches.isDesIf_MigrationEnabled.returns(false)
-        def taxYear: TaxYear = TaxYear.fromMtd("2017-18")
+        def taxYear: TaxYear                                  = TaxYear.fromMtd("2017-18")
         val deleteRequest: DeleteOtherEmploymentIncomeRequest = DeleteOtherEmploymentIncomeRequest(Nino(nino), taxYear)
-        val outcome: Right[Nothing, ResponseWrapper[Unit]] = Right(ResponseWrapper(correlationId, ()))
+        val outcome: Right[Nothing, ResponseWrapper[Unit]]    = Right(ResponseWrapper(correlationId, ()))
 
         willDelete(url"$baseUrl/income-tax/income/other/employments/$nino/2017-18") returns Future.successful(outcome)
 
         await(connector.deleteOtherEmploymentIncome(deleteRequest)) shouldBe outcome
       }
 
-      "the downstream call is successful and is tax year specific" in new TysIfsTest with Test
-      with ConnectorTest {
-        def taxYear: TaxYear = TaxYear.fromMtd("2023-24")
+      "the downstream call is successful and is tax year specific" in new IfsTest with Test with ConnectorTest {
+        def taxYear: TaxYear                                  = TaxYear.fromMtd("2023-24")
         val deleteRequest: DeleteOtherEmploymentIncomeRequest = DeleteOtherEmploymentIncomeRequest(Nino(nino), taxYear)
-        val outcome: Right[Nothing, ResponseWrapper[Unit]] = Right(ResponseWrapper(correlationId, ()))
+        val outcome: Right[Nothing, ResponseWrapper[Unit]]    = Right(ResponseWrapper(correlationId, ()))
 
         willDelete(url"$baseUrl/income-tax/income/other/employments/23-24/$nino") returns Future.successful(outcome)
 
         await(connector.deleteOtherEmploymentIncome(deleteRequest)) shouldBe outcome
       }
 
-      "the downstream call is successful, not tax year specific and 'isDesIf_MigrationEnabled' is on" in new IfsTest
-      with Test with ConnectorTest {
+      "the downstream call is successful, not tax year specific and 'isDesIf_MigrationEnabled' is on" in new IfsTest with Test with ConnectorTest {
         MockFeatureSwitches.isDesIf_MigrationEnabled.returns(true)
 
         def taxYear: TaxYear = TaxYear.fromMtd("2017-18")
 
         val deleteRequest: DeleteOtherEmploymentIncomeRequest = DeleteOtherEmploymentIncomeRequest(Nino(nino), taxYear)
-        val outcome: Right[Nothing, ResponseWrapper[Unit]] = Right(ResponseWrapper(correlationId, ()))
+        val outcome: Right[Nothing, ResponseWrapper[Unit]]    = Right(ResponseWrapper(correlationId, ()))
 
         willDelete(url"$baseUrl/income-tax/2017-18/income/other/employments/$nino") returns Future.successful(outcome)
 
@@ -86,7 +83,8 @@ class OtherEmploymentIncomeConnectorSpec extends ConnectorSpec with MockFeatureS
 
     "return a 200 result on retrieve" when {
       "the downstream call is successful, is not tax year specific and 'isDesIf_MigrationEnabled' is off" in new DesTest
-      with Test with ConnectorTest {
+        with Test
+        with ConnectorTest {
         MockFeatureSwitches.isDesIf_MigrationEnabled.returns(false)
         def taxYear: TaxYear = TaxYear.fromMtd("2021-22")
 
@@ -103,8 +101,7 @@ class OtherEmploymentIncomeConnectorSpec extends ConnectorSpec with MockFeatureS
         await(connector.retrieveOtherEmploymentIncome(retrieveRequest)) shouldBe outcome
       }
 
-      "the downstream call is successful, is not tax year specific and 'isDesIf_MigrationEnabled' is on" in new IfsTest
-      with Test with ConnectorTest {
+      "the downstream call is successful, is not tax year specific and 'isDesIf_MigrationEnabled' is on" in new IfsTest with Test with ConnectorTest {
         MockFeatureSwitches.isDesIf_MigrationEnabled.returns(true)
         def taxYear: TaxYear = TaxYear.fromMtd("2021-22")
 
@@ -116,14 +113,12 @@ class OtherEmploymentIncomeConnectorSpec extends ConnectorSpec with MockFeatureS
         val outcome: Right[Nothing, ResponseWrapper[RetrieveOtherEmploymentResponse]] =
           Right(ResponseWrapper(correlationId, retrieveResponse))
 
-        willGet(url"$baseUrl/income-tax/${taxYear.asMtd}/income/other/employments/$nino") returns Future.successful(
-          outcome)
+        willGet(url"$baseUrl/income-tax/${taxYear.asMtd}/income/other/employments/$nino") returns Future.successful(outcome)
 
         await(connector.retrieveOtherEmploymentIncome(retrieveRequest)) shouldBe outcome
       }
 
-      "the downstream call is successful and is tax year specific" in new TysIfsTest with Test
-      with ConnectorTest {
+      "the downstream call is successful and is tax year specific" in new IfsTest with Test with ConnectorTest {
         def taxYear: TaxYear = TaxYear.fromMtd("2023-24")
 
         val retrieveRequest: RetrieveOtherEmploymentIncomeRequest =

--- a/test/v1/connectors/RetrieveEmploymentAndFinancialDetailsConnectorSpec.scala
+++ b/test/v1/connectors/RetrieveEmploymentAndFinancialDetailsConnectorSpec.scala
@@ -33,8 +33,8 @@ import scala.concurrent.Future
 
 class RetrieveEmploymentAndFinancialDetailsConnectorSpec extends EmploymentsConnectorSpec {
 
-  val nino: String = "AA123456A"
-  val employmentId: String = "4557ecb5-fd32-48cc-81f5-e6acd1099f3c"
+  val nino: String          = "AA123456A"
+  val employmentId: String  = "4557ecb5-fd32-48cc-81f5-e6acd1099f3c"
   val source: MtdSourceEnum = MtdSourceEnum.latest
 
   val queryParams: Seq[(String, String)] = Seq(("view", source.toDesViewString))
@@ -82,20 +82,24 @@ class RetrieveEmploymentAndFinancialDetailsConnectorSpec extends EmploymentsConn
     "return the expected response for a TYS request" when {
 
       "downstream returns OK" when {
-        "the connector sends a valid request downstream with a Tax Year Specific (TYS) tax year on IFS" in new MockEmploymentsAppConfig with TysIfsTest with Test {
+        "the connector sends a valid request downstream with a Tax Year Specific (TYS) tax year on IFS" in new MockEmploymentsAppConfig
+          with IfsTest
+          with Test {
           MockedSharedAppConfig.featureSwitchConfig.returns(Configuration("ifs_hip_migration_1877.enabled" -> false)).atLeastOnce()
           override def taxYear: TaxYear = TaxYear.fromMtd("2023-24")
-          val expected = Right(ResponseWrapper(correlationId, response))
+          val expected                  = Right(ResponseWrapper(correlationId, response))
 
           stubIfsHttpResponse(expected)
 
           await(connector.retrieve(request)) shouldBe expected
         }
 
-        "the connector sends a valid request downstream with a Tax Year Specific (TYS) tax year on HIP" in new MockEmploymentsAppConfig with HipTest with Test {
+        "the connector sends a valid request downstream with a Tax Year Specific (TYS) tax year on HIP" in new MockEmploymentsAppConfig
+          with HipTest
+          with Test {
           MockedSharedAppConfig.featureSwitchConfig.returns(Configuration("ifs_hip_migration_1877.enabled" -> true)).atLeastOnce()
           override def taxYear: TaxYear = TaxYear.fromMtd("2023-24")
-          val expected = Right(ResponseWrapper(correlationId, response))
+          val expected                  = Right(ResponseWrapper(correlationId, response))
 
           stubHipHttpResponse(expected)
 
@@ -121,21 +125,21 @@ class RetrieveEmploymentAndFinancialDetailsConnectorSpec extends EmploymentsConn
         employmentsAppConfig = mockEmploymentsConfig)
 
     protected def stubHttpResponse(outcome: DownstreamOutcome[RetrieveEmploymentAndFinancialDetailsResponse])
-      : CallHandler[Future[DownstreamOutcome[RetrieveEmploymentAndFinancialDetailsResponse]]]#Derived =
+        : CallHandler[Future[DownstreamOutcome[RetrieveEmploymentAndFinancialDetailsResponse]]]#Derived =
       willGet(
         url = url"$baseUrl/income-tax/income/employments/$nino/${taxYear.asMtd}/$employmentId",
         queryParams
       ).returns(Future.successful(outcome))
 
     protected def stubIfsHttpResponse(outcome: DownstreamOutcome[RetrieveEmploymentAndFinancialDetailsResponse])
-      : CallHandler[Future[DownstreamOutcome[RetrieveEmploymentAndFinancialDetailsResponse]]]#Derived =
+        : CallHandler[Future[DownstreamOutcome[RetrieveEmploymentAndFinancialDetailsResponse]]]#Derived =
       willGet(
         url = url"$baseUrl/income-tax/income/employments/${taxYear.asTysDownstream}/$nino/$employmentId",
         queryParams
       ).returns(Future.successful(outcome))
 
     protected def stubHipHttpResponse(outcome: DownstreamOutcome[RetrieveEmploymentAndFinancialDetailsResponse])
-    : CallHandler[Future[DownstreamOutcome[RetrieveEmploymentAndFinancialDetailsResponse]]]#Derived =
+        : CallHandler[Future[DownstreamOutcome[RetrieveEmploymentAndFinancialDetailsResponse]]]#Derived =
       willGet(
         url = url"$baseUrl/itsa/income-tax/v1/${taxYear.asTysDownstream}/income/employments/$nino/$employmentId",
         queryParams

--- a/test/v1/connectors/RetrieveNonPayeEmploymentConnectorSpec.scala
+++ b/test/v1/connectors/RetrieveNonPayeEmploymentConnectorSpec.scala
@@ -47,7 +47,7 @@ class RetrieveNonPayeEmploymentConnectorSpec extends EmploymentsConnectorSpec {
     }
 
     "retrieveUkDividendsIncomeAnnualSummary is called for a TaxYearSpecific tax year" must {
-      "return a 200 for success scenario" in new MockEmploymentsAppConfig with TysIfsTest with Test {
+      "return a 200 for success scenario" in new MockEmploymentsAppConfig with IfsTest with Test {
         def taxYear: TaxYear = TaxYear.fromMtd("2023-24")
 
         val outcome = Right(ResponseWrapper(correlationId, responseModel))
@@ -64,10 +64,7 @@ class RetrieveNonPayeEmploymentConnectorSpec extends EmploymentsConnectorSpec {
     def taxYear: TaxYear
 
     protected val connector: RetrieveNonPayeEmploymentConnector =
-      new RetrieveNonPayeEmploymentConnector(
-        http = mockHttpClient,
-        appConfig = mockSharedAppConfig,
-        employmentsAppConfig = mockEmploymentsConfig)
+      new RetrieveNonPayeEmploymentConnector(http = mockHttpClient, appConfig = mockSharedAppConfig, employmentsAppConfig = mockEmploymentsConfig)
 
     protected val request: RetrieveNonPayeEmploymentIncomeRequest =
       RetrieveNonPayeEmploymentIncomeRequest(Nino("AA111111A"), taxYear = taxYear, MtdSourceEnum.latest)

--- a/test/v1/connectors/UnignoreEmploymentConnectorSpec.scala
+++ b/test/v1/connectors/UnignoreEmploymentConnectorSpec.scala
@@ -30,7 +30,7 @@ class UnignoreEmploymentConnectorSpec extends ConnectorSpec {
 
   "UnignoreEmploymentConnector" should {
     "return the expected response for a TYS IFS request" when {
-      "a valid request is made" in new TysIfsTest with Test {
+      "a valid request is made" in new IfsTest with Test {
         val expectedOutcome: Right[Nothing, ResponseWrapper[Unit]] = Right(ResponseWrapper(correlationId, ()))
 
         MockedSharedAppConfig.featureSwitchConfig returns Configuration("ifs_hip_migration_1800.enabled" -> false)
@@ -63,7 +63,7 @@ class UnignoreEmploymentConnectorSpec extends ConnectorSpec {
   trait Test { _: ConnectorTest =>
     val taxYear: TaxYear = TaxYear.fromMtd("2023-24")
 
-    val nino: String = "AA111111A"
+    val nino: String         = "AA111111A"
     val employmentId: String = "4557ecb5-fd32-48cc-81f5-e6acd1099f3c"
 
     val request: UnignoreEmploymentRequest = UnignoreEmploymentRequest(

--- a/test/v2/connectors/AmendFinancialDetailsConnectorSpec.scala
+++ b/test/v2/connectors/AmendFinancialDetailsConnectorSpec.scala
@@ -46,7 +46,7 @@ class AmendFinancialDetailsConnectorSpec extends EmploymentsConnectorSpec {
 
       }
 
-      "a valid request is submitted for a TYS tax year" in new TysIfsTest with MockEmploymentsAppConfig with Test {
+      "a valid request is submitted for a TYS tax year" in new IfsTest with MockEmploymentsAppConfig with Test {
         def taxYear = TaxYear.fromMtd("2023-24")
 
         val outcome = Right(ResponseWrapper(correlationId, ()))

--- a/test/v2/connectors/AmendOtherEmploymentConnectorSpec.scala
+++ b/test/v2/connectors/AmendOtherEmploymentConnectorSpec.scala
@@ -31,7 +31,7 @@ class AmendOtherEmploymentConnectorSpec extends ConnectorSpec {
     "return the expected response for a non-TYS request" when {
       "a valid request is made" in new DesTest with Test {
         def taxYear: TaxYear = TaxYear.fromMtd("2019-20")
-        val outcome = Right(ResponseWrapper(correlationId, ()))
+        val outcome          = Right(ResponseWrapper(correlationId, ()))
 
         willPut(
           url = url"$baseUrl/income-tax/income/other/employments/$nino/2019-20",
@@ -68,9 +68,9 @@ class AmendOtherEmploymentConnectorSpec extends ConnectorSpec {
       }
     }
     "return the expected response for a TYS request" when {
-      "a valid request is made" in new TysIfsTest with Test {
+      "a valid request is made" in new IfsTest with Test {
         def taxYear: TaxYear = TaxYear.fromMtd("2023-24")
-        val outcome = Right(ResponseWrapper(correlationId, ()))
+        val outcome          = Right(ResponseWrapper(correlationId, ()))
 
         willPut(
           url = url"$baseUrl/income-tax/income/other/employments/23-24/$nino",

--- a/test/v2/connectors/CreateAmendNonPayeEmploymentConnectorSpec.scala
+++ b/test/v2/connectors/CreateAmendNonPayeEmploymentConnectorSpec.scala
@@ -62,7 +62,7 @@ class CreateAmendNonPayeEmploymentConnectorSpec extends EmploymentsConnectorSpec
         await(connector.createAndAmend(request)) shouldBe outcome
       }
 
-      "a valid request is made for a TYS tax year" in new MockEmploymentsAppConfig with TysIfsTest with Test {
+      "a valid request is made for a TYS tax year" in new MockEmploymentsAppConfig with IfsTest with Test {
         val taxYear: TaxYear = TaxYear.fromMtd("2023-24")
 
         val outcome: Right[Nothing, ResponseWrapper[Unit]] = Right(ResponseWrapper(correlationId, ()))

--- a/test/v2/connectors/DeleteEmploymentFinancialDetailsConnectorSpec.scala
+++ b/test/v2/connectors/DeleteEmploymentFinancialDetailsConnectorSpec.scala
@@ -32,7 +32,7 @@ class DeleteEmploymentFinancialDetailsConnectorSpec extends EmploymentsConnector
     "return the expected response for a non-TYS request" when {
       "a valid request is made" in new Release6Test with Test {
         def taxYear: TaxYear = TaxYear.fromMtd("2019-20")
-        val outcome = Right(ResponseWrapper(correlationId, ()))
+        val outcome          = Right(ResponseWrapper(correlationId, ()))
 
         willDelete(
           url = url"$baseUrl/income-tax/income/employments/$nino/2019-20/$employmentId"
@@ -43,9 +43,9 @@ class DeleteEmploymentFinancialDetailsConnectorSpec extends EmploymentsConnector
     }
 
     "return the expected response for a TYS request" when {
-      "a valid request is made" in new MockEmploymentsAppConfig with TysIfsTest with Test {
+      "a valid request is made" in new MockEmploymentsAppConfig with IfsTest with Test {
         def taxYear: TaxYear = TaxYear.fromMtd("2023-24")
-        val outcome = Right(ResponseWrapper(correlationId, ()))
+        val outcome          = Right(ResponseWrapper(correlationId, ()))
 
         willDelete(
           url = url"$baseUrl/income-tax/23-24/income/employments/$nino/$employmentId"
@@ -61,7 +61,7 @@ class DeleteEmploymentFinancialDetailsConnectorSpec extends EmploymentsConnector
 
     def taxYear: TaxYear
 
-    protected val nino: String = "AA111111A"
+    protected val nino: String         = "AA111111A"
     protected val employmentId: String = "4557ecb5-fd32-48cc-81f5-e6acd1099f3c"
 
     protected val request: DeleteEmploymentFinancialDetailsRequest =

--- a/test/v2/connectors/DeleteNonPayeEmploymentConnectorSpec.scala
+++ b/test/v2/connectors/DeleteNonPayeEmploymentConnectorSpec.scala
@@ -45,7 +45,7 @@ class DeleteNonPayeEmploymentConnectorSpec extends EmploymentsConnectorSpec {
     }
 
     "deleteNonPayeEmployment is called for a TaxYearSpecific tax year" must {
-      "return a 200 for success scenario" in new MockEmploymentsAppConfig with TysIfsTest with Test {
+      "return a 200 for success scenario" in new MockEmploymentsAppConfig with IfsTest with Test {
         def taxYear: TaxYear = TaxYear.fromMtd("2023-24")
 
         val outcome = Right(ResponseWrapper(correlationId, ()))
@@ -63,10 +63,7 @@ class DeleteNonPayeEmploymentConnectorSpec extends EmploymentsConnectorSpec {
     def taxYear: TaxYear
 
     protected val connector: DeleteNonPayeEmploymentConnector =
-      new DeleteNonPayeEmploymentConnector(
-        http = mockHttpClient,
-        appConfig = mockSharedAppConfig,
-        employmentsAppConfig = mockEmploymentsConfig)
+      new DeleteNonPayeEmploymentConnector(http = mockHttpClient, appConfig = mockSharedAppConfig, employmentsAppConfig = mockEmploymentsConfig)
 
     protected val request: DeleteNonPayeEmploymentRequest =
       DeleteNonPayeEmploymentRequest(Nino("AA111111A"), taxYear = taxYear)

--- a/test/v2/connectors/IgnoreEmploymentConnectorSpec.scala
+++ b/test/v2/connectors/IgnoreEmploymentConnectorSpec.scala
@@ -28,7 +28,7 @@ import scala.concurrent.Future
 
 class IgnoreEmploymentConnectorSpec extends ConnectorSpec {
 
-  val nino: String = "AA111111A"
+  val nino: String         = "AA111111A"
   val employmentId: String = "4557ecb5-fd32-48cc-81f5-e6acd1099f3c"
 
   trait Test { _: ConnectorTest =>
@@ -50,7 +50,7 @@ class IgnoreEmploymentConnectorSpec extends ConnectorSpec {
 
   "ignoreEmployment" when {
     "given a valid request" should {
-      "return a success response when feature switch is disabled(IFS enabled)" in new TysIfsTest with Test with ConnectorTest {
+      "return a success response when feature switch is disabled(IFS enabled)" in new IfsTest with Test with ConnectorTest {
         MockedSharedAppConfig.featureSwitchConfig returns Configuration("ifs_hip_migration_1940.enabled" -> false)
         willPut(
           url = url"$baseUrl/income-tax/21-22/income/employments/$nino/$employmentId/ignore",

--- a/test/v2/connectors/OtherEmploymentIncomeConnectorSpec.scala
+++ b/test/v2/connectors/OtherEmploymentIncomeConnectorSpec.scala
@@ -45,37 +45,34 @@ class OtherEmploymentIncomeConnectorSpec extends ConnectorSpec with MockFeatureS
 
   "OtherEmploymentIncomeConnector" should {
     "return a 200 result on delete" when {
-      "the downstream call is successful, not tax year specific and 'isDesIf_MigrationEnabled' is off" in new DesTest
-      with Test with ConnectorTest {
+      "the downstream call is successful, not tax year specific and 'isDesIf_MigrationEnabled' is off" in new DesTest with Test with ConnectorTest {
         MockFeatureSwitches.isDesIf_MigrationEnabled.returns(false)
-        def taxYear: TaxYear = TaxYear.fromMtd("2017-18")
+        def taxYear: TaxYear                                  = TaxYear.fromMtd("2017-18")
         val deleteRequest: DeleteOtherEmploymentIncomeRequest = DeleteOtherEmploymentIncomeRequest(Nino(nino), taxYear)
-        val outcome: Right[Nothing, ResponseWrapper[Unit]] = Right(ResponseWrapper(correlationId, ()))
+        val outcome: Right[Nothing, ResponseWrapper[Unit]]    = Right(ResponseWrapper(correlationId, ()))
 
         willDelete(url"$baseUrl/income-tax/income/other/employments/$nino/2017-18") returns Future.successful(outcome)
 
         await(connector.deleteOtherEmploymentIncome(deleteRequest)) shouldBe outcome
       }
 
-      "the downstream call is successful and is tax year specific" in new TysIfsTest with Test
-      with ConnectorTest {
-        def taxYear: TaxYear = TaxYear.fromMtd("2023-24")
+      "the downstream call is successful and is tax year specific" in new IfsTest with Test with ConnectorTest {
+        def taxYear: TaxYear                                  = TaxYear.fromMtd("2023-24")
         val deleteRequest: DeleteOtherEmploymentIncomeRequest = DeleteOtherEmploymentIncomeRequest(Nino(nino), taxYear)
-        val outcome: Right[Nothing, ResponseWrapper[Unit]] = Right(ResponseWrapper(correlationId, ()))
+        val outcome: Right[Nothing, ResponseWrapper[Unit]]    = Right(ResponseWrapper(correlationId, ()))
 
         willDelete(url"$baseUrl/income-tax/income/other/employments/23-24/$nino") returns Future.successful(outcome)
 
         await(connector.deleteOtherEmploymentIncome(deleteRequest)) shouldBe outcome
       }
 
-      "the downstream call is successful, not tax year specific and 'isDesIf_MigrationEnabled' is on" in new IfsTest
-      with Test with ConnectorTest {
+      "the downstream call is successful, not tax year specific and 'isDesIf_MigrationEnabled' is on" in new IfsTest with Test with ConnectorTest {
         MockFeatureSwitches.isDesIf_MigrationEnabled.returns(true)
 
         def taxYear: TaxYear = TaxYear.fromMtd("2017-18")
 
         val deleteRequest: DeleteOtherEmploymentIncomeRequest = DeleteOtherEmploymentIncomeRequest(Nino(nino), taxYear)
-        val outcome: Right[Nothing, ResponseWrapper[Unit]] = Right(ResponseWrapper(correlationId, ()))
+        val outcome: Right[Nothing, ResponseWrapper[Unit]]    = Right(ResponseWrapper(correlationId, ()))
 
         willDelete(url"$baseUrl/income-tax/2017-18/income/other/employments/$nino") returns Future.successful(outcome)
 
@@ -86,7 +83,8 @@ class OtherEmploymentIncomeConnectorSpec extends ConnectorSpec with MockFeatureS
 
     "return a 200 result on retrieve" when {
       "the downstream call is successful, is not tax year specific and 'isDesIf_MigrationEnabled' is off" in new DesTest
-      with Test with ConnectorTest {
+        with Test
+        with ConnectorTest {
         MockFeatureSwitches.isDesIf_MigrationEnabled.returns(false)
         def taxYear: TaxYear = TaxYear.fromMtd("2021-22")
 
@@ -103,8 +101,7 @@ class OtherEmploymentIncomeConnectorSpec extends ConnectorSpec with MockFeatureS
         await(connector.retrieveOtherEmploymentIncome(retrieveRequest)) shouldBe outcome
       }
 
-      "the downstream call is successful, is not tax year specific and 'isDesIf_MigrationEnabled' is on" in new IfsTest
-      with Test with ConnectorTest {
+      "the downstream call is successful, is not tax year specific and 'isDesIf_MigrationEnabled' is on" in new IfsTest with Test with ConnectorTest {
         MockFeatureSwitches.isDesIf_MigrationEnabled.returns(true)
         def taxYear: TaxYear = TaxYear.fromMtd("2021-22")
 
@@ -116,14 +113,12 @@ class OtherEmploymentIncomeConnectorSpec extends ConnectorSpec with MockFeatureS
         val outcome: Right[Nothing, ResponseWrapper[RetrieveOtherEmploymentResponse]] =
           Right(ResponseWrapper(correlationId, retrieveResponse))
 
-        willGet(url"$baseUrl/income-tax/${taxYear.asMtd}/income/other/employments/$nino") returns Future.successful(
-          outcome)
+        willGet(url"$baseUrl/income-tax/${taxYear.asMtd}/income/other/employments/$nino") returns Future.successful(outcome)
 
         await(connector.retrieveOtherEmploymentIncome(retrieveRequest)) shouldBe outcome
       }
 
-      "the downstream call is successful and is tax year specific" in new TysIfsTest with Test
-      with ConnectorTest {
+      "the downstream call is successful and is tax year specific" in new IfsTest with Test with ConnectorTest {
         def taxYear: TaxYear = TaxYear.fromMtd("2023-24")
 
         val retrieveRequest: RetrieveOtherEmploymentIncomeRequest =

--- a/test/v2/connectors/RetrieveEmploymentAndFinancialDetailsConnectorSpec.scala
+++ b/test/v2/connectors/RetrieveEmploymentAndFinancialDetailsConnectorSpec.scala
@@ -33,8 +33,8 @@ import scala.concurrent.Future
 
 class RetrieveEmploymentAndFinancialDetailsConnectorSpec extends EmploymentsConnectorSpec {
 
-  val nino: String = "AA123456A"
-  val employmentId: String = "4557ecb5-fd32-48cc-81f5-e6acd1099f3c"
+  val nino: String          = "AA123456A"
+  val employmentId: String  = "4557ecb5-fd32-48cc-81f5-e6acd1099f3c"
   val source: MtdSourceEnum = MtdSourceEnum.latest
 
   val queryParams: Seq[(String, String)] = Seq(("view", source.toDesViewString))
@@ -82,20 +82,24 @@ class RetrieveEmploymentAndFinancialDetailsConnectorSpec extends EmploymentsConn
     "return the expected response for a TYS request" when {
 
       "downstream returns OK" when {
-        "the connector sends a valid request downstream with a Tax Year Specific (TYS) tax year on IFS" in new MockEmploymentsAppConfig with TysIfsTest with Test {
+        "the connector sends a valid request downstream with a Tax Year Specific (TYS) tax year on IFS" in new MockEmploymentsAppConfig
+          with IfsTest
+          with Test {
           MockedSharedAppConfig.featureSwitchConfig.returns(Configuration("ifs_hip_migration_1877.enabled" -> false)).atLeastOnce()
           override def taxYear: TaxYear = TaxYear.fromMtd("2023-24")
-          val expected = Right(ResponseWrapper(correlationId, response))
+          val expected                  = Right(ResponseWrapper(correlationId, response))
 
           stubIfsHttpResponse(expected)
 
           await(connector.retrieve(request)) shouldBe expected
         }
 
-        "the connector sends a valid request downstream with a Tax Year Specific (TYS) tax year on HIP" in new MockEmploymentsAppConfig with HipTest with Test {
+        "the connector sends a valid request downstream with a Tax Year Specific (TYS) tax year on HIP" in new MockEmploymentsAppConfig
+          with HipTest
+          with Test {
           MockedSharedAppConfig.featureSwitchConfig.returns(Configuration("ifs_hip_migration_1877.enabled" -> true)).atLeastOnce()
           override def taxYear: TaxYear = TaxYear.fromMtd("2023-24")
-          val expected = Right(ResponseWrapper(correlationId, response))
+          val expected                  = Right(ResponseWrapper(correlationId, response))
 
           stubHipHttpResponse(expected)
 
@@ -121,21 +125,21 @@ class RetrieveEmploymentAndFinancialDetailsConnectorSpec extends EmploymentsConn
         employmentsAppConfig = mockEmploymentsConfig)
 
     protected def stubHttpResponse(outcome: DownstreamOutcome[RetrieveEmploymentAndFinancialDetailsResponse])
-      : CallHandler[Future[DownstreamOutcome[RetrieveEmploymentAndFinancialDetailsResponse]]]#Derived =
+        : CallHandler[Future[DownstreamOutcome[RetrieveEmploymentAndFinancialDetailsResponse]]]#Derived =
       willGet(
         url = url"$baseUrl/income-tax/income/employments/$nino/${taxYear.asMtd}/$employmentId",
         queryParams
       ).returns(Future.successful(outcome))
 
     protected def stubIfsHttpResponse(outcome: DownstreamOutcome[RetrieveEmploymentAndFinancialDetailsResponse])
-      : CallHandler[Future[DownstreamOutcome[RetrieveEmploymentAndFinancialDetailsResponse]]]#Derived =
+        : CallHandler[Future[DownstreamOutcome[RetrieveEmploymentAndFinancialDetailsResponse]]]#Derived =
       willGet(
         url = url"$baseUrl/income-tax/income/employments/${taxYear.asTysDownstream}/$nino/$employmentId",
         queryParams
       ).returns(Future.successful(outcome))
 
     protected def stubHipHttpResponse(outcome: DownstreamOutcome[RetrieveEmploymentAndFinancialDetailsResponse])
-    : CallHandler[Future[DownstreamOutcome[RetrieveEmploymentAndFinancialDetailsResponse]]]#Derived =
+        : CallHandler[Future[DownstreamOutcome[RetrieveEmploymentAndFinancialDetailsResponse]]]#Derived =
       willGet(
         url = url"$baseUrl/itsa/income-tax/v1/${taxYear.asTysDownstream}/income/employments/$nino/$employmentId",
         queryParams

--- a/test/v2/connectors/RetrieveNonPayeEmploymentConnectorSpec.scala
+++ b/test/v2/connectors/RetrieveNonPayeEmploymentConnectorSpec.scala
@@ -47,7 +47,7 @@ class RetrieveNonPayeEmploymentConnectorSpec extends EmploymentsConnectorSpec {
     }
 
     "retrieveUkDividendsIncomeAnnualSummary is called for a TaxYearSpecific tax year" must {
-      "return a 200 for success scenario" in new MockEmploymentsAppConfig with TysIfsTest with Test {
+      "return a 200 for success scenario" in new MockEmploymentsAppConfig with IfsTest with Test {
         def taxYear: TaxYear = TaxYear.fromMtd("2023-24")
 
         val outcome = Right(ResponseWrapper(correlationId, responseModel))
@@ -64,10 +64,7 @@ class RetrieveNonPayeEmploymentConnectorSpec extends EmploymentsConnectorSpec {
     def taxYear: TaxYear
 
     protected val connector: RetrieveNonPayeEmploymentConnector =
-      new RetrieveNonPayeEmploymentConnector(
-        http = mockHttpClient,
-        appConfig = mockSharedAppConfig,
-        employmentsAppConfig = mockEmploymentsConfig)
+      new RetrieveNonPayeEmploymentConnector(http = mockHttpClient, appConfig = mockSharedAppConfig, employmentsAppConfig = mockEmploymentsConfig)
 
     protected val request: RetrieveNonPayeEmploymentIncomeRequest =
       RetrieveNonPayeEmploymentIncomeRequest(Nino("AA111111A"), taxYear = taxYear, MtdSourceEnum.latest)

--- a/test/v2/connectors/UnignoreEmploymentConnectorSpec.scala
+++ b/test/v2/connectors/UnignoreEmploymentConnectorSpec.scala
@@ -30,7 +30,7 @@ class UnignoreEmploymentConnectorSpec extends ConnectorSpec {
 
   "UnignoreEmploymentConnector" should {
     "return the expected response for a TYS IFS request" when {
-      "a valid request is made" in new TysIfsTest with Test {
+      "a valid request is made" in new IfsTest with Test {
         val expectedOutcome: Right[Nothing, ResponseWrapper[Unit]] = Right(ResponseWrapper(correlationId, ()))
 
         MockedSharedAppConfig.featureSwitchConfig returns Configuration("ifs_hip_migration_1800.enabled" -> false)
@@ -63,7 +63,7 @@ class UnignoreEmploymentConnectorSpec extends ConnectorSpec {
   trait Test { _: ConnectorTest =>
     val taxYear: TaxYear = TaxYear.fromMtd("2023-24")
 
-    val nino: String = "AA111111A"
+    val nino: String         = "AA111111A"
     val employmentId: String = "4557ecb5-fd32-48cc-81f5-e6acd1099f3c"
 
     val request: UnignoreEmploymentRequest = UnignoreEmploymentRequest(


### PR DESCRIPTION
PR links for all the config files
1. [https://github.com/hmrc/app-config-development/pull/9769](https://github.com/hmrc/app-config-development/pull/9769)
2. [https://github.com/hmrc/app-config-qa/pull/25809](https://github.com/hmrc/app-config-qa/pull/25809)
3. [https://github.com/hmrc/app-config-staging/pull/17769](https://github.com/hmrc/app-config-staging/pull/17769)
4. [https://github.com/hmrc/app-config-externaltest/pull/5655](https://github.com/hmrc/app-config-externaltest/pull/5655)
5. [https://github.com/hmrc/app-config-production/pull/25936](https://github.com/hmrc/app-config-production/pull/25936)
6. [https://github.com/hmrc/app-config-base/pull/12317](https://github.com/hmrc/app-config-base/pull/12317)